### PR TITLE
Simple fix

### DIFF
--- a/eu2020/common/event_processor.py
+++ b/eu2020/common/event_processor.py
@@ -14,8 +14,8 @@ class EventProcessor:
     def add_events(self, events: PartiesEvents) -> None:
         self.events.append(events)
         parties = events.get_parties().parties
-        for p in parties.keys():
-            if p not in self.all_parties.parties.keys():
+        for p in parties:
+            if p not in self.all_parties.parties:
                 self.all_parties.parties[p] = parties[p]
 
     def process_events(self, budget: Budget) -> None:

--- a/eu2020/common/name.py
+++ b/eu2020/common/name.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import re
 import eu2020.data.texts as texts
 

--- a/eu2020/common/parties.py
+++ b/eu2020/common/parties.py
@@ -13,7 +13,7 @@ class Parties:
     def get_satisfaction_pct(self) -> float:
         i = 0
         s = 0
-        for c in self.parties.keys():
+        for c in self.parties:
             s += self.parties[c]["satisfaction_pct"]
             i += 1
         return s / i
@@ -21,12 +21,12 @@ class Parties:
     def get_detailed_satisfaction_report(self) -> str:
         result = ""
         w = 0
-        for c in self.parties.keys():
+        for c in self.parties:
             t = len(self.parties[c]["name"])
             if w < t:
                 w = t
         w += 3
-        for c in self.parties.keys():
+        for c in self.parties:
             result += self.parties[c]["name"]
             for _ in range(w - len(self.parties[c]["name"])):
                 result += " "
@@ -38,20 +38,20 @@ class Parties:
         return result
 
     def update_satisfaction(self, satisfaction: dict) -> None:
-        for c in satisfaction.keys():
+        for c in satisfaction:
             self.parties[c]["satisfaction_pct"] += satisfaction[c]
             if self.parties[c]["satisfaction_pct"] < 0:
                 self.parties[c]["satisfaction_pct"] = 0
 
     def get_budget_contribution(self) -> int:
         result = 0
-        for c in self.parties.keys():
+        for c in self.parties:
             result += self.parties[c]["budget_contribution"]
         return result
 
     def get_budget_consumption(self) -> int:
         result = 0
-        for c in self.parties.keys():
+        for c in self.parties:
             result += self.parties[c]["budget_consumption"]
         return result
 

--- a/eu2020/common/utils.py
+++ b/eu2020/common/utils.py
@@ -14,9 +14,9 @@ def print_text_in_box(text: str, ch="*") -> None:
 
 def input_with_options(question: str, options: dict) -> str:
     a = None
-    while a not in options.keys():
+    while a not in options:
         print(question)
-        for o in options.keys():
+        for o in options:
             print(f"{o} - {options[o]}")
         a = input("> ")
     clear()

--- a/eu2020/data/data.py
+++ b/eu2020/data/data.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 gender = {"m": "muž", "f": "žena", "n": "nebinární"}
 
 months = ["Leden", "Únor", "Březen", "Duben", "Květen", "Červen", "Červenec", "Srpen", "Září", "Říjen", "Listopad", "Prosinec"]

--- a/eu2020/data/ev_deep_state.py
+++ b/eu2020/data/ev_deep_state.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 ev_deep_state = [
     {
         "party": "SOR",

--- a/eu2020/data/ev_higher_power.py
+++ b/eu2020/data/ev_higher_power.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 ev_higher_power = [
     {
         "key": "PAN",

--- a/eu2020/data/ev_members.py
+++ b/eu2020/data/ev_members.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 ev_member_country = [
     {
         "party": "CZ",

--- a/eu2020/data/texts.py
+++ b/eu2020/data/texts.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 app_name = "EU Diktátor 2020"
 
 what_is_your_name = "Jak se jmenuješ? "

--- a/eu2020/tests/test_name.py
+++ b/eu2020/tests/test_name.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import unittest
 from eu2020.common.name import Name
 

--- a/eu2020/tests/test_name.py
+++ b/eu2020/tests/test_name.py
@@ -15,9 +15,9 @@ names = {
 class TestName(unittest.TestCase):
 
     def testName5p(self):
-        for key in names.keys():
-            name = Name(key, "m")
-            self.assertEqual(names[key], name.get_name5p())
+        for name1p, name5p in names.items():
+            name = Name(name1p, "m")
+            self.assertEqual(name5p, name.get_name5p())
 
 
 if __name__ == "__main__":

--- a/eu2020/tests/test_period.py
+++ b/eu2020/tests/test_period.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import unittest
 from eu2020.common.period import Period
 


### PR DESCRIPTION
Ahoj, posilam PR se dvema upravami:

1) kdyz se u pythonovych slovniku iteruje `for x in d` nebo testuje pritomnost `if k in d` tak se automaticky berou jen klice, tzn. neni potreba volat `.keys()`

2) u zdrojovych kodu s Unicode znaky mimo zakladni ASCII je jistejsi dat na zacatek komentar s informaci o kodovani