### PR TITLE
Remove duplicate args to .format

### DIFF
--- a/eu2020/app.py
+++ b/eu2020/app.py
@@ -86,14 +86,14 @@ def print_budget(budget: Budget) -> None:
 
 
 def print_membership_satisfaction(members: Parties) -> None:
-    console.print(texts.membership_satisfaction.format(colors.numbers, members.get_satisfaction_pct(), colors.numbers))
+    console.print(texts.membership_satisfaction.format(colors.numbers, members.get_satisfaction_pct()))
 
 
 def print_hp_events(hp_events: HigherPowerEvents) -> None:
     ev = hp_events.get_current_events()
     if ev != "":
         console.print()
-        console.print(texts.higher_power_events.format(colors.high_power_events, ev, colors.high_power_events))
+        console.print(texts.higher_power_events.format(colors.high_power_events, ev))
 
 
 def setup() -> None:

--- a/eu2020/common/budget.py
+++ b/eu2020/common/budget.py
@@ -64,16 +64,16 @@ class Budget:
     def get_budget_report(self):
         result = ""
 
-        result += "{} [{}]{:20,} EUR[/{}]\n" \
-            .format(texts.budget_income, colors.numbers, self.get_income(), colors.numbers)
-        result += "{} [{}]{:20,} EUR[/{}]\n" \
-            .format(texts.budget_outcome, colors.numbers, self.get_outcome(), colors.numbers)
-        result += "{} [{}]{:20,} EUR[/{}]\n" \
-            .format(texts.budget_extra_income, colors.numbers, self.get_extra_income(), colors.numbers)
-        result += "{} [{}]{:20,} EUR[/{}]\n" \
-            .format(texts.budget_extra_outcome, colors.numbers, self.get_extra_outcome(), colors.numbers)
-        result += "{} [{}]{:20,} EUR[/{}]\n" \
-            .format(texts.budget_dept, colors.numbers, self.get_dept(), colors.numbers)
+        result += "{0} [{1}]{2:20,} EUR[/{1}]\n" \
+            .format(texts.budget_income, colors.numbers, self.get_income())
+        result += "{0} [{1}]{2:20,} EUR[/{1}]\n" \
+            .format(texts.budget_outcome, colors.numbers, self.get_outcome())
+        result += "{0} [{1}]{2:20,} EUR[/{1}]\n" \
+            .format(texts.budget_extra_income, colors.numbers, self.get_extra_income())
+        result += "{0} [{1}]{2:20,} EUR[/{1}]\n" \
+            .format(texts.budget_extra_outcome, colors.numbers, self.get_extra_outcome())
+        result += "{0} [{1}]{2:20,} EUR[/{1}]\n" \
+            .format(texts.budget_dept, colors.numbers, self.get_dept())
 
         diff = self.get_balance()
         color = colors.numbers
@@ -81,9 +81,9 @@ class Budget:
             color = colors.positive_progress
         if diff < 0:
             color = colors.negative_progress
-        result += "{} [{}]{:{}20,} EUR[/{}]\n".format(texts.budget_balance, color, diff, '+' if diff else '', color)
+        result += "{0} [{1}]{2:{3}20,} EUR[/{1}]\n".format(texts.budget_balance, color, diff, '+' if diff else '')
 
-        result += "{} [{}]{:20,} EUR[/{}]\n" \
-            .format(texts.budget_guarantee, colors.numbers, self.get_guarantee(), colors.numbers)
+        result += "{0} [{1}]{2:20,} EUR[/{1}]\n" \
+            .format(texts.budget_guarantee, colors.numbers, self.get_guarantee())
 
         return result

--- a/eu2020/common/parties.py
+++ b/eu2020/common/parties.py
@@ -30,12 +30,12 @@ class Parties:
             result += self.parties[c]["name"]
             for _ in range(w - len(self.parties[c]["name"])):
                 result += " "
-            result += "[{}]{:.2f} %[/{}]".format(colors.numbers, self.parties[c]["satisfaction_pct"], colors.numbers)
+            result += "[{0}]{1:.2f} %[/{0}]".format(colors.numbers, self.parties[c]["satisfaction_pct"])
             diff = self.parties[c]["satisfaction_pct"] - self.parties_prev[c]["satisfaction_pct"]
             if diff > 0:
-                result += "  ([{}]{:+.2f} %[/{}])".format(colors.positive_progress, diff, colors.positive_progress)
+                result += "  ([{0}]{1:+.2f} %[/{0}])".format(colors.positive_progress, diff)
             if diff < 0:
-                result += "  ([{}]{:+.2f} %[/{}])".format(colors.negative_progress, diff, colors.negative_progress)
+                result += "  ([{0}]{1:+.2f} %[/{0}])".format(colors.negative_progress, diff)
             result += "\n"
         return result
 

--- a/eu2020/data/texts.py
+++ b/eu2020/data/texts.py
@@ -13,7 +13,7 @@ proceed = "Pokračovat..."
 
 period = "Období: {} {}"
 # budget = "Rozpočet {}: {:,} EUR, rozdíl příjmů a výdajů: {:,} EUR, dluh: {:,} EUR"
-membership_satisfaction = "Spokojenost členských států: [{}]{:.2f} %[/{}]"
+membership_satisfaction = "Spokojenost členských států: [{0}]{1:.2f} %[/{0}]"
 membership_satisfaction_header = "Spokojenost členských států"
 deep_state_satisfaction_header = "Spokojenost deep state"
 
@@ -33,7 +33,7 @@ gender_dict = {
 
 options = "Možnosti:"
 higher_power_event = "Mimořádná událost"
-higher_power_events = "Mimořádné události: [{}]{}[/{}]"
+higher_power_events = "Mimořádné události: [{0}]{1}[/{0}]"
 
 budget_income =        "Příjmy:                 "
 budget_outcome =       "Výdaje:                 "


### PR DESCRIPTION
Ahoj, navrhuju malou úpravu týkající se metody `.format`:

Obecně když máš např.

```
"{} {} {}".format(color, text, color)
```

můžeš to přepsat jako

```
"{0} {1} {0}".format(color, text)
```

https://docs.python.org/3/library/string.html#format-examples
